### PR TITLE
Fix participant count query and modality update

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/repository/ParticipantRepository.java
+++ b/src/main/java/br/org/fenae/jogosfenae/repository/ParticipantRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Integer> {
 
-    @Query("SELECT COUNT(*) FROM Participant p JOIN Company c ON p.company.id = c.id WHERE c.id = :companyId")
+    @Query("SELECT COUNT(p) FROM Participant p WHERE p.company.companyId = :companyId")
     Integer findByCompanyId(@Param("companyId") Integer companyId);
 
 }

--- a/src/main/java/br/org/fenae/jogosfenae/service/ModalityService.java
+++ b/src/main/java/br/org/fenae/jogosfenae/service/ModalityService.java
@@ -30,8 +30,8 @@ public class ModalityService {
 
     @Transactional
     public void updateModality(Integer modalityId, Modality modality){
-        modality.setModalityId(modalityId);
-        Modality updateModality = findByIdModality(modality.getModalityId());
+        Modality updateModality = findByIdModality(modalityId);
+        updateModality.setName(modality.getName());
         modalityRepository.save(updateModality);
     }
 


### PR DESCRIPTION
## Summary
- fix participant lookup query for company
- properly update modality name

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840300921dc832f960b66816e88f745