### PR TITLE
Add Edition endpoints

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/controller/EditionController.java
+++ b/src/main/java/br/org/fenae/jogosfenae/controller/EditionController.java
@@ -1,0 +1,59 @@
+package br.org.fenae.jogosfenae.controller;
+
+import br.org.fenae.jogosfenae.entity.Edition;
+import br.org.fenae.jogosfenae.service.EditionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import javax.validation.Valid;
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rest/v1/edition")
+public class EditionController {
+
+    @Autowired
+    private EditionService editionService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public ResponseEntity<Void> save(@Valid @RequestBody Edition edition) {
+        editionService.saveEdition(edition);
+        URI uri = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{editionId}")
+                .buildAndExpand(edition.getEditionId())
+                .toUri();
+        return ResponseEntity.created(uri).build();
+    }
+
+    @GetMapping("/{editionId}")
+    public ResponseEntity<Edition> findById(@PathVariable Integer editionId) {
+        return ResponseEntity.ok(editionService.findById(editionId));
+    }
+
+    @GetMapping("/title/{title}")
+    public ResponseEntity<Edition> findByTitle(@PathVariable String title) {
+        return ResponseEntity.ok(editionService.findByTitle(title));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Edition>> findAll() {
+        return ResponseEntity.ok(editionService.findAll());
+    }
+
+    @PutMapping("/{editionId}")
+    public ResponseEntity<Void> update(@PathVariable Integer editionId, @RequestBody Edition edition) {
+        editionService.updateEdition(editionId, edition);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{editionId}")
+    public ResponseEntity<Void> delete(@PathVariable Integer editionId) {
+        editionService.deleteEdition(editionId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
@@ -1,0 +1,31 @@
+package br.org.fenae.jogosfenae.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "fenae_Edition")
+public class Edition extends AbstractEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonProperty("editionId")
+    private Integer editionId;
+
+    @Column(unique = true)
+    @NotNull(message = "Campo é obrigatório")
+    private String title;
+
+    @NotNull(message = "Campo é obrigatório")
+    private String description;
+}

--- a/src/main/java/br/org/fenae/jogosfenae/repository/EditionRepository.java
+++ b/src/main/java/br/org/fenae/jogosfenae/repository/EditionRepository.java
@@ -1,0 +1,12 @@
+package br.org.fenae.jogosfenae.repository;
+
+import br.org.fenae.jogosfenae.entity.Edition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EditionRepository extends JpaRepository<Edition, Integer> {
+    Optional<Edition> findByTitleIgnoreCase(String title);
+}

--- a/src/main/java/br/org/fenae/jogosfenae/service/EditionService.java
+++ b/src/main/java/br/org/fenae/jogosfenae/service/EditionService.java
@@ -1,0 +1,59 @@
+package br.org.fenae.jogosfenae.service;
+
+import br.org.fenae.jogosfenae.entity.Edition;
+import br.org.fenae.jogosfenae.exception.NoSuchElementFoundException;
+import br.org.fenae.jogosfenae.repository.EditionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class EditionService {
+
+    @Autowired
+    private EditionRepository editionRepository;
+
+    @Transactional
+    public Edition saveEdition(Edition edition) {
+        edition.setEditionId(null);
+        return editionRepository.save(edition);
+    }
+
+    public Edition findById(Integer editionId) {
+        Optional<Edition> edition = editionRepository.findById(editionId);
+        return edition.orElseThrow(() ->
+                new NoSuchElementFoundException("Edição não encontrada: " + Edition.class.getName()));
+    }
+
+    public Edition findByTitle(String title) {
+        Optional<Edition> edition = editionRepository.findByTitleIgnoreCase(title);
+        return edition.orElseThrow(() ->
+                new NoSuchElementFoundException("Edição não encontrada: " + Edition.class.getName()));
+    }
+
+    public List<Edition> findAll() {
+        return editionRepository.findAll();
+    }
+
+    @Transactional
+    public void updateEdition(Integer editionId, Edition edition) {
+        Edition update = findById(editionId);
+        update.setTitle(edition.getTitle());
+        update.setDescription(edition.getDescription());
+        editionRepository.save(update);
+    }
+
+    @Transactional
+    public void deleteEdition(Integer editionId) {
+        findById(editionId);
+        try {
+            editionRepository.deleteById(editionId);
+        } catch (DataIntegrityViolationException e) {
+            throw new NoSuchElementFoundException("Não é possível excluir a edição!");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Edition entity with title and description
- create EditionRepository for database access
- implement EditionService with CRUD operations
- expose EditionController endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe65d834832f9956c7206a240a07