### PR TITLE
Enable Swagger UI with Springdoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<repackage.classifier/>
 		<spring-native.version>0.12.1</spring-native.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -54,11 +54,18 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <optional>true</optional>
+                </dependency>
+
+                <!-- Swagger/OpenAPI UI -->
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-ui</artifactId>
+                        <version>1.7.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add springdoc-openapi-ui dependency for automatic Swagger UI

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846231eb930832fac27cc347e785a3b