### PR TITLE
Fix date parsing and use MySQL profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ $ git clone https://github.com/rbrodrigues1980/jogosfenae.git
 
 # Abra ou importe o projeto no IntelliJ IDEA (ou uma IDE de sua preferência)
 # Execute VendasApplication
-O servidor iniciará na porta:8080
+O servidor iniciará na porta:8080 usando o perfil **prod**, que conecta ao banco
+de dados MySQL configurado em `application-prod.properties`.
 
 Para acessar a documentação da API acesse <http://localhost:8080/swagger-ui.html>
 

--- a/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
@@ -18,12 +18,13 @@ public abstract class AbstractEntity {
 
     @Column(name = "createdDateTime")
     @CreationTimestamp
-    @JsonFormat(pattern="dd-MM-yyyy HH:mm:ss")
+    // Accept ISO 8601 date time strings such as "2025-06-09T00:02:55.958Z"
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     private LocalDateTime createdDateTime;
 
     @Column(name = "updatedDateTime")
     @UpdateTimestamp
-    @JsonFormat(pattern="dd-MM-yyyy HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
     private LocalDateTime updatedDateTime;
 
     //SOLID e desing pattern

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-spring.profiles.active=dev
+# Default to the MySQL profile so the application uses the real database
+spring.profiles.active=prod


### PR DESCRIPTION
## Summary
- default to the prod profile so MySQL is used
- accept ISO-8601 timestamps on entity base class
- clarify README about running with MySQL

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846268b5d58832fabd06711bca2094a