### PR TITLE
Use camelCase names for schema

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
@@ -17,7 +17,12 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "fenae_Company")
+@Table(
+        name = "fenaeCompany",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "FENAE_UK_COMPANY_NAME", columnNames = "name")
+        }
+)
 @Log
 public class Company extends AbstractEntity{
 

--- a/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
@@ -14,7 +14,12 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "fenae_Edition")
+@Table(
+        name = "fenaeEdition",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "FENAE_UK_EDITION_TITLE", columnNames = "title")
+        }
+)
 public class Edition extends AbstractEntity {
 
     @Id

--- a/src/main/java/br/org/fenae/jogosfenae/entity/Modality.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Modality.java
@@ -15,7 +15,12 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "fenae_Modality")
+@Table(
+        name = "fenaeModality",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "FENAE_UK_MODALITY_NAME", columnNames = "name")
+        }
+)
 @Log
 public class Modality extends AbstractEntity {
 

--- a/src/main/java/br/org/fenae/jogosfenae/entity/Participant.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Participant.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 //@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-@Table(name = "fenae_Participant")
+@Table(name = "fenaeParticipant")
 public class Participant extends AbstractEntity {
 
     @Id

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,3 +11,6 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
 server.error.include-message = always
+
+# Use standard naming strategy to keep camelCase table and column names
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -12,3 +12,6 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 
 server.error.include-message = always
+
+# Use standard naming strategy to keep camelCase table and column names
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
## Summary
- keep camelCase table and column names
- add explicit names for unique constraints
- use standard Hibernate naming strategy

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684630577714832f9a953426eb8fddf8