### PR TITLE
Format timestamps without milliseconds

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
@@ -18,13 +18,13 @@ public abstract class AbstractEntity {
 
     @Column(name = "createdDateTime")
     @CreationTimestamp
-    // Accept ISO 8601 date time strings such as "2025-06-09T00:02:55.958Z"
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    // Format dates without milliseconds, e.g. "2024-06-12 17:05:57"
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdDateTime;
 
     @Column(name = "updatedDateTime")
     @UpdateTimestamp
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime updatedDateTime;
 
     //SOLID e desing pattern


### PR DESCRIPTION
## Summary
- format `createdDateTime` and `updatedDateTime` in JSON without milliseconds

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68463586f934832fad9bb40c26c76667