### PR TITLE
Fix ParticipantRepository query to use company id

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/repository/ParticipantRepository.java
+++ b/src/main/java/br/org/fenae/jogosfenae/repository/ParticipantRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ParticipantRepository extends JpaRepository<Participant, String> {
 
-    @Query("SELECT COUNT(p) FROM Participant p WHERE p.company.companyId = :companyId")
+    @Query("SELECT COUNT(p) FROM Participant p WHERE p.company.id = :companyId")
     Integer findByCompanyId(@Param("companyId") String companyId);
 
 }


### PR DESCRIPTION
## Summary
- fix ParticipantRepository query to check `company.id` not `company.companyId`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846bd6046b8832f85cab8d7febb73eb