### PR TITLE
Add pt-BR locale message bundle

### DIFF
--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -1,0 +1,1 @@
+validation.field.required=Campo é obrigatório


### PR DESCRIPTION
## Summary
- add `messages_pt_BR.properties` mirroring default Portuguese messages

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846c1d9f3e8832fa5846168ccefbdeb