### PR TITLE
Fix company save validation

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
@@ -49,7 +49,6 @@ public class Company extends AbstractEntity{
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "editionId", nullable = false, foreignKey = @ForeignKey(name = "EDICAO_FK_EDICAOID"))
-    @NotNull(message = "{validation.field.required}")
     private Edition edition;
 
     public void setTitle(String title) {


### PR DESCRIPTION
## Summary
- allow company creation without `edition` in JSON body

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cea54aa68832f877736f44ad44949