### PR TITLE
Fix duplicate company per edition

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
@@ -20,13 +20,13 @@ import javax.validation.constraints.NotNull;
 @Table(
         name = "fenae_Company",
         uniqueConstraints = {
-                @UniqueConstraint(name = "FENAE_UK_COMPANY_NAME", columnNames = "title")
+                @UniqueConstraint(name = "FENAE_UK_COMPANY_EDITION_TITLE", columnNames = {"title", "editionId"})
         }
 )
 @Log
 public class Company extends AbstractEntity{
 
-    @Column(unique = true)
+    @Column
     @NotNull(message = "{validation.field.required}")
     private String title;
 


### PR DESCRIPTION
## Summary
- allow duplicate company titles across different editions by updating unique constraint in `Company` entity

## Testing
- `mvn test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cec92de04832fbff66b66e240cee9