### PR TITLE
Add non-negative validation for company numbers

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Company.java
@@ -10,6 +10,7 @@ import lombok.extern.java.Log;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -31,20 +32,26 @@ public class Company extends AbstractEntity{
     private String title;
 
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer participantNumber;
 
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer presidentNumber;
 
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer sportsDirectorNumber;
 
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer athleteNumber;
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer parathleteNumber;
 
     @NotNull(message = "{validation.field.required}")
+    @PositiveOrZero(message = "{validation.field.nonnegative}")
     private Integer technicalNumber;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -4,3 +4,4 @@ validation.edition.start.before.end=Data de início deve ser anterior à data fi
 validation.edition.birth.range=Data inicial de nascimento deve ser anterior ou igual à data final
 validation.edition.membership.before.start=Data de filiação deve ser anterior ou igual à data de início
 validation.edition.invalid=Dados de edição inválidos
+validation.field.nonnegative=Valor não pode ser negativo

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -3,3 +3,4 @@ validation.edition.start.before.end=Start date must be before end date
 validation.edition.birth.range=Birth start date must be before or equal to end date
 validation.edition.membership.before.start=Membership date must be on or before start date
 validation.edition.invalid=Edition data is invalid
+validation.field.nonnegative=Value must be zero or positive

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -4,3 +4,4 @@ validation.edition.start.before.end=Data de início deve ser anterior à data fi
 validation.edition.birth.range=Data inicial de nascimento deve ser anterior ou igual à data final
 validation.edition.membership.before.start=Data de filiação deve ser anterior ou igual à data de início
 validation.edition.invalid=Dados de edição inválidos
+validation.field.nonnegative=Valor não pode ser negativo


### PR DESCRIPTION
## Summary
- enforce non-negative numbers in `Company` entity
- add i18n messages for new validation rule

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d65cb95d8832fad490789ec6fa8a4