### PR TITLE
Ensure audit fields are read‑only

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/AbstractEntity.java
@@ -18,17 +18,19 @@ import java.time.LocalDateTime;
 public abstract class AbstractEntity {
 
     @Id
-    @JsonProperty("id")
+    @JsonProperty(value = "id", access = JsonProperty.Access.READ_ONLY)
     @Column(length = 32)
     private String id;
 
     @Column(name = "createdDateTime")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime createdDateTime;
 
     @Column(name = "updatedDateTime")
     @UpdateTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime updatedDateTime;
 }

--- a/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
+++ b/src/main/java/br/org/fenae/jogosfenae/entity/Edition.java
@@ -1,6 +1,7 @@
 package br.org.fenae.jogosfenae.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -31,35 +32,41 @@ public class Edition extends AbstractEntity {
     @Column(name = "startDateTime")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @NotNull(message = "{validation.field.required}")
     private LocalDateTime startDateTime;
 
     @Column(name = "endDateTime")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @NotNull(message = "{validation.field.required}")
     private LocalDateTime endDateTime;
 
     @Column(name = "membershipDate")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     @NotNull(message = "{validation.field.required}")
     private LocalDate membershipDate;
 
     @Column(name = "bornFrom")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDate bornFrom;
 
     @Schema(description = "Nascidos até")
     @Column(name = "bornUntil")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDate bornUntil;
 
     @Column(name = "linkExpirationDate")
     @CreationTimestamp
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime linkExpirationDate;
 
     private String link;


### PR DESCRIPTION
## Summary
- make timestamp fields read-only in `Edition`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d4c3c88832faa94f1ebabb97f1b