### PR TITLE
Fix edition update for all fields

### DIFF
--- a/src/main/java/br/org/fenae/jogosfenae/service/EditionService.java
+++ b/src/main/java/br/org/fenae/jogosfenae/service/EditionService.java
@@ -50,6 +50,14 @@ public class EditionService {
     public void updateEdition(String editionId, Edition edition) {
         Edition update = findById(editionId);
         update.setTitle(edition.getTitle());
+        update.setStartDateTime(edition.getStartDateTime());
+        update.setEndDateTime(edition.getEndDateTime());
+        update.setMembershipDate(edition.getMembershipDate());
+        update.setBornFrom(edition.getBornFrom());
+        update.setBornUntil(edition.getBornUntil());
+        update.setLinkExpirationDate(edition.getLinkExpirationDate());
+        update.setLink(edition.getLink());
+        update.setEmail(edition.getEmail());
         update.setDescription(edition.getDescription());
         update.setCurrentEdition(edition.getCurrentEdition());
         editionRepository.save(update);

--- a/src/test/java/br/org/fenae/jogosfenae/service/EditionServiceTest.java
+++ b/src/test/java/br/org/fenae/jogosfenae/service/EditionServiceTest.java
@@ -12,6 +12,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +38,14 @@ class EditionServiceTest {
     void setUp() {
         sampleEdition = Edition.builder()
                 .title("Title")
+                .startDateTime(LocalDateTime.parse("2020-01-01T10:00:00"))
+                .endDateTime(LocalDateTime.parse("2020-01-10T12:00:00"))
+                .membershipDate(LocalDate.parse("2020-01-05"))
+                .bornFrom(LocalDate.parse("1980-01-01"))
+                .bornUntil(LocalDate.parse("2005-12-31"))
+                .linkExpirationDate(LocalDateTime.parse("2020-12-31T23:59:00"))
+                .link("http://example.com")
+                .email("test@example.com")
                 .description("Description")
                 .currentEdition(true)
                 .build();
@@ -133,6 +143,14 @@ class EditionServiceTest {
 
         Edition newValues = Edition.builder()
                 .title("Updated")
+                .startDateTime(LocalDateTime.parse("2021-02-01T09:00:00"))
+                .endDateTime(LocalDateTime.parse("2021-02-10T18:00:00"))
+                .membershipDate(LocalDate.parse("2021-02-05"))
+                .bornFrom(LocalDate.parse("1985-01-01"))
+                .bornUntil(LocalDate.parse("2010-12-31"))
+                .linkExpirationDate(LocalDateTime.parse("2021-12-31T23:00:00"))
+                .link("http://updated.com")
+                .email("upd@example.com")
                 .description("UpdatedDesc")
                 .currentEdition(false)
                 .build();
@@ -140,6 +158,14 @@ class EditionServiceTest {
         editionService.updateEdition("ED1", newValues);
 
         assertEquals("Updated", sampleEdition.getTitle());
+        assertEquals(LocalDateTime.parse("2021-02-01T09:00:00"), sampleEdition.getStartDateTime());
+        assertEquals(LocalDateTime.parse("2021-02-10T18:00:00"), sampleEdition.getEndDateTime());
+        assertEquals(LocalDate.parse("2021-02-05"), sampleEdition.getMembershipDate());
+        assertEquals(LocalDate.parse("1985-01-01"), sampleEdition.getBornFrom());
+        assertEquals(LocalDate.parse("2010-12-31"), sampleEdition.getBornUntil());
+        assertEquals(LocalDateTime.parse("2021-12-31T23:00:00"), sampleEdition.getLinkExpirationDate());
+        assertEquals("http://updated.com", sampleEdition.getLink());
+        assertEquals("upd@example.com", sampleEdition.getEmail());
         assertEquals("UpdatedDesc", sampleEdition.getDescription());
         assertFalse(sampleEdition.getCurrentEdition());
         verify(editionRepository).save(sampleEdition);


### PR DESCRIPTION
## Summary
- update `updateEdition` to set date, link and email fields
- expand tests to cover new update logic

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684e24c480c4832f9a278a892b9d60a3